### PR TITLE
Add CLAUDE.md and expand README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,11 +11,12 @@ A personal homepage rendered as an interactive terminal emulator. Built with Cre
 ```bash
 yarn start          # dev server (react-scripts start)
 yarn build          # production build into build/
-yarn tsc            # typecheck (noEmit) — this is what CI runs as "test"
+yarn test           # react-scripts test (Jest) — finds no tests; see note
 yarn deploy         # build + publish (see Deploy below)
+yarn tsc            # typecheck via node_modules/.bin/tsc (noEmit) — NOT a package.json script
 ```
 
-There is **no jest test suite** (no `*.spec`/`*.test` files exist). `yarn test` exists but the CI "test" job runs `yarn tsc` for typechecking instead. ESLint is configured (`.eslintrc.cjs`) but there is no `lint` script; formatting is enforced by Prettier via a Husky pre-commit hook (`pretty-quick --staged`).
+There is **no jest test suite** (no `*.spec`/`*.test` files exist), so `yarn test` has nothing to run. CI's "test" job runs `yarn tsc` instead — that typecheck, not `yarn test`, is the real verification gate. `yarn tsc` is not a defined script; Yarn resolves it to the `tsc` binary in `node_modules/.bin`. ESLint is configured (`.eslintrc.cjs`) but there is no `lint` script. Formatting is enforced by Prettier via the Husky `.husky/pre-commit` hook (`pretty-quick --staged`) — note the `husky`/`lint-staged` block in `package.json` is stale dead config that Husky v8 ignores.
 
 Node: `.tool-versions` pins 22.15.0 locally; CI (`.circleci/config.yml`) pins 16.14.2.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+A personal homepage rendered as an interactive terminal emulator. Built with Create React App (react-scripts 5), React 17, and TypeScript in strict mode. Served at `console.drn.dev` (see `CNAME`) / `drn.github.io`.
+
+## Commands
+
+```bash
+yarn start          # dev server (react-scripts start)
+yarn build          # production build into build/
+yarn tsc            # typecheck (noEmit) — this is what CI runs as "test"
+yarn deploy         # build + publish (see Deploy below)
+```
+
+There is **no jest test suite** (no `*.spec`/`*.test` files exist). `yarn test` exists but the CI "test" job runs `yarn tsc` for typechecking instead. ESLint is configured (`.eslintrc.cjs`) but there is no `lint` script; formatting is enforced by Prettier via a Husky pre-commit hook (`pretty-quick --staged`).
+
+Node: `.tool-versions` pins 22.15.0 locally; CI (`.circleci/config.yml`) pins 16.14.2.
+
+## Architecture
+
+The app is a single-page React Router app (`src/App.tsx`) with two routes:
+
+- `/` → `Terminal` — the interactive shell UI
+- `/slack/callback` → `Slack` — renders an OAuth auth code for the user to copy
+
+### Terminal command system
+
+The terminal (`src/Terminal/`) reads a line of input (`Input.tsx`), passes it to an `Executor` (`src/Terminal/Executor/index.tsx`), and renders the result as a new `Row`. This is the core extension point.
+
+`Executor` constructs each registered command, keying it by its `name`, then on each run parses input into `{ command, arguments }` (split on spaces) and dispatches to the matching command. Unknown commands return `zsh: command not found: …`.
+
+Commands implement two interfaces (`Runnable`, `Nameable`):
+
+- `name: string` — the command word typed in the terminal
+- `run(args: string[])` → `{ success, result?, builtins? }` where `result` can be a React node
+
+**To add a command:** create a class in `src/Terminal/Executor/` implementing `Runnable, Nameable`, then add it to the `commands` array in `src/Terminal/Executor/index.tsx`. Existing examples: `Cat`, `Clear`, `Help`, `List` (`ls`), `Whoami`, `Spotify`.
+
+**Built-in side effects:** a command can return `builtins: ['clear']` to trigger a side effect handled by `Executor.builtin()` (which can call `setContents` to manipulate terminal state). When a command returns builtins, the run `halt`s and no command/result rows are appended.
+
+### OAuth-via-clipboard flow
+
+`Spotify` and `Slack` implement a clipboard-based auth handoff: the callback route copies the auth `code` to the clipboard for the user to paste back into the terminal. The Terminal route reads `code`/`state` params and pre-fills the input (e.g. `spotify <code>`) when `state === 'spotify'`.
+
+## Deploy
+
+`yarn deploy` runs `./deploy`, which: aborts on a dirty tree, builds, **destructively replaces the working tree with `build/` contents** (`rm -rf public src yarn.lock README.md deploy`), commits, force-pushes to `upstream HEAD:production`, then `git reset --hard HEAD^` to restore source. The CircleCI `deploy` job only triggers on the `production` branch. Be careful editing `deploy` — it deletes source files in the working copy as a normal part of operation.
+
+## Conventions
+
+Prettier (`.prettierrc`): no semicolons, single quotes, trailing commas everywhere, 80-col width. TypeScript `strict` is on. `lodash` is used throughout (imported as `_`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,10 +21,7 @@ Node: `.tool-versions` pins 22.15.0 locally; CI (`.circleci/config.yml`) pins 16
 
 ## Architecture
 
-The app is a single-page React Router app (`src/App.tsx`) with two routes:
-
-- `/` → `Terminal` — the interactive shell UI
-- `/slack/callback` → `Slack` — renders an OAuth auth code for the user to copy
+The app is a single-page React Router app (`src/App.tsx`); the main route `/` renders the `Terminal` — the interactive shell UI.
 
 ### Terminal command system
 
@@ -37,13 +34,9 @@ Commands implement two interfaces (`Runnable`, `Nameable`):
 - `name: string` — the command word typed in the terminal
 - `run(args: string[])` → `{ success, result?, builtins? }` where `result` can be a React node
 
-**To add a command:** create a class in `src/Terminal/Executor/` implementing `Runnable, Nameable`, then add it to the `commands` array in `src/Terminal/Executor/index.tsx`. Existing examples: `Cat`, `Clear`, `Help`, `List` (`ls`), `Whoami`, `Spotify`.
+**To add a command:** create a class in `src/Terminal/Executor/` implementing `Runnable, Nameable`, then add it to the `commands` array in `src/Terminal/Executor/index.tsx`. Existing examples: `Cat`, `Clear`, `Help`, `List` (`ls`), `Whoami`.
 
 **Built-in side effects:** a command can return `builtins: ['clear']` to trigger a side effect handled by `Executor.builtin()` (which can call `setContents` to manipulate terminal state). When a command returns builtins, the run `halt`s and no command/result rows are appended.
-
-### OAuth-via-clipboard flow
-
-`Spotify` and `Slack` implement a clipboard-based auth handoff: the callback route copies the auth `code` to the clipboard for the user to paste back into the terminal. The Terminal route reads `code`/`state` params and pre-fills the input (e.g. `spotify <code>`) when `state === 'spotify'`.
 
 ## Deploy
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,36 @@
-## [Home Terminal](https://drn.github.io/)
+## [Home Terminal](https://console.drn.dev/)
 
 [![CircleCI](https://circleci.com/gh/drn/drn.github.io.svg?style=svg)](https://circleci.com/gh/drn/drn.github.io)
+
+A personal homepage rendered as an interactive terminal emulator, live at
+[console.drn.dev](https://console.drn.dev/). Built with Create React App,
+React 17, and TypeScript.
 
 ---
 
 ### Commands
 
+Run the dev server:
+
+    yarn start
+
+Typecheck (what CI runs):
+
+    yarn tsc
+
+Build:
+
+    yarn build
+
 Deploy:
 
     yarn deploy
+
+### Adding a terminal command
+
+Create a class in `src/Terminal/Executor/` implementing the `Runnable` and
+`Nameable` interfaces, then register it in the `commands` array in
+`src/Terminal/Executor/index.tsx`.
 
 ### License
 


### PR DESCRIPTION
Document the terminal-emulator architecture for future contributors and
expand the README.

- Add CLAUDE.md: commands (incl. the yarn tsc typecheck gate vs the empty
  jest suite), the Terminal command system (Input → Executor → Row, the
  Runnable/Nameable interfaces, registering commands, builtins/halt), the
  destructive ./deploy flow, and Prettier/TypeScript conventions.
- README: point at the live console.drn.dev, add a description, list
  dev/typecheck/build commands, and document how to add a terminal command.

Co-Authored-By: Claude <noreply@anthropic.com>